### PR TITLE
Renamed fields for consistency

### DIFF
--- a/PyMatchaV2.postman_collection.json
+++ b/PyMatchaV2.postman_collection.json
@@ -6065,7 +6065,7 @@
 									"tests[\"Message is correct\"] = response.new_messages.length == 1",
 									"tests[\"New message content is correct\"] = response.new_messages[0].content == \"My Reply\"",
 									"tests[\"New message is_seen\"] = response.new_messages[0].is_seen == 0",
-									"tests[\"New message seen timestamp is null\"] = response.new_messages[0].seen_timestamp == null"
+									"tests[\"New message seen timestamp is null\"] = response.new_messages[0].dt_seen == null"
 								],
 								"type": "text/javascript"
 							}

--- a/backend/PyMatcha/models/image.py
+++ b/backend/PyMatcha/models/image.py
@@ -33,14 +33,14 @@ class Image(Model):
     id = Field(int, modifiable=False)
     user_id = Field(int)
     link = Field(str)
-    timestamp = Field(datetime, fmt="%Y-%m-%d %H:%M:%S")
+    dt_added = Field(datetime, fmt="%Y-%m-%d %H:%M:%S")
     is_primary = Field(bool)
 
     @staticmethod
-    def create(user_id: int, link: str, is_primary: bool = False, timestamp: Optional[datetime] = None) -> Image:
-        if not timestamp:
-            timestamp = datetime.utcnow()
-        new_image = Image(user_id=user_id, link=link, is_primary=is_primary, timestamp=timestamp)
+    def create(user_id: int, link: str, is_primary: bool = False, dt_added: Optional[datetime] = None) -> Image:
+        if not dt_added:
+            dt_added = datetime.utcnow()
+        new_image = Image(user_id=user_id, link=link, is_primary=is_primary, dt_added=dt_added)
         new_image.save()
         logging.debug("Creating new image")
         return new_image

--- a/backend/PyMatcha/models/message.py
+++ b/backend/PyMatcha/models/message.py
@@ -68,11 +68,11 @@ class Message(Model):
 
     def to_dict(self) -> Dict:
         returned_dict = super().to_dict()
-        returned_dict["timestamp_ago"] = timeago_format(self.timestamp, datetime.utcnow())
-        if self.seen_timestamp:
-            returned_dict["seen_timestamp_ago"] = timeago_format(self.seen_timestamp, datetime.utcnow())
+        returned_dict["dt_sent_ago"] = timeago_format(self.dt_sent, datetime.utcnow())
+        if self.dt_seen:
+            returned_dict["dt_seen_ago"] = timeago_format(self.dt_seen, datetime.utcnow())
         else:
-            returned_dict["seen_timestamp_ago"] = None
+            returned_dict["dt_seen_ago"] = None
 
         return returned_dict
 

--- a/backend/PyMatcha/models/message.py
+++ b/backend/PyMatcha/models/message.py
@@ -35,8 +35,8 @@ class Message(Model):
     id = Field(int, modifiable=False)
     from_id = Field(int)
     to_id = Field(int)
-    timestamp = Field(datetime, fmt="%Y-%m-%d %H:%M:%S")
-    seen_timestamp = Field(datetime, fmt="%Y-%m-%d %H:%M:%S")
+    dt_sent = Field(datetime, fmt="%Y-%m-%d %H:%M:%S")
+    dt_seen = Field(datetime, fmt="%Y-%m-%d %H:%M:%S")
     content = Field(str)
     is_seen = Field(bool)
     is_liked = Field(bool)
@@ -46,19 +46,19 @@ class Message(Model):
         from_id: int,
         to_id: int,
         content: str,
-        timestamp: Optional[datetime] = None,
-        seen_timestamp: Optional[datetime] = None,
+        dt_sent: Optional[datetime] = None,
+        dt_seen: Optional[datetime] = None,
         is_seen: bool = False,
         is_liked: bool = False,
     ) -> Message:
-        if not timestamp:
-            timestamp = datetime.utcnow()
+        if not dt_sent:
+            dt_sent = datetime.utcnow()
         new_message = Message(
             from_id=from_id,
             to_id=to_id,
             content=content,
-            timestamp=timestamp,
-            seen_timestamp=seen_timestamp,
+            dt_sent=dt_sent,
+            dt_seen=dt_seen,
             is_seen=is_seen,
             is_liked=is_liked,
         )

--- a/backend/PyMatcha/models/user.py
+++ b/backend/PyMatcha/models/user.py
@@ -60,8 +60,8 @@ class User(Model):
     geohash = Field(str)
     heat_score = Field(int)
     is_online = Field(bool)
-    date_joined = Field(datetime.datetime, fmt="%Y-%m-%d %H:%M:%S")
-    date_lastseen = Field(datetime.datetime, fmt="%Y-%m-%d %H:%M:%S")
+    dt_joined = Field(datetime.datetime, fmt="%Y-%m-%d %H:%M:%S")
+    dt_lastseen = Field(datetime.datetime, fmt="%Y-%m-%d %H:%M:%S")
     is_profile_completed = Field(bool)
     is_confirmed = Field(bool)
     confirmed_on = Field(datetime.datetime, fmt="%Y-%m-%d %H:%M:%S")
@@ -84,8 +84,8 @@ class User(Model):
         geohash: str,
         heat_score: int = 0,
         is_online: bool = False,
-        date_joined: Optional[datetime.datetime] = None,
-        date_lastseen: Optional[datetime.datetime] = None,
+        dt_joined: Optional[datetime.datetime] = None,
+        dt_lastseen: Optional[datetime.datetime] = None,
         is_profile_completed: bool = False,
         is_confirmed: bool = False,
         confirmed_on: datetime.datetime = None,
@@ -126,11 +126,11 @@ class User(Model):
         # Encrypt password
         password = hash_password(password)
 
-        if not date_joined:
-            date_joined = datetime.datetime.utcnow()
+        if not dt_joined:
+            dt_joined = datetime.datetime.utcnow()
 
-        if not date_lastseen:
-            date_lastseen = datetime.datetime.utcnow()
+        if not dt_lastseen:
+            dt_lastseen = datetime.datetime.utcnow()
 
         new_user = User(
             first_name=first_name,
@@ -145,8 +145,8 @@ class User(Model):
             geohash=geohash,
             heat_score=heat_score,
             is_online=is_online,
-            date_joined=date_joined,
-            date_lastseen=date_lastseen,
+            dt_joined=dt_joined,
+            dt_lastseen=dt_lastseen,
             is_profile_completed=is_profile_completed,
             is_confirmed=is_confirmed,
             confirmed_on=confirmed_on,
@@ -187,8 +187,8 @@ class User(Model):
             geohash=None,
             heat_score=0,
             is_online=False,
-            date_joined=datetime.datetime.utcnow(),
-            date_lastseen=datetime.datetime.utcnow(),
+            dt_joined=datetime.datetime.utcnow(),
+            dt_lastseen=datetime.datetime.utcnow(),
             is_profile_completed=False,
             is_confirmed=False,
             confirmed_on=None,
@@ -211,7 +211,7 @@ class User(Model):
         returned_dict["likes"] = {"sent": [], "received": []}
         returned_dict["likes"]["sent"] = [like.to_dict() for like in self.get_likes_sent()]
         returned_dict["likes"]["received"] = [like.to_dict() for like in self.get_likes_received()]
-        returned_dict["last_seen"] = timeago_format(self.date_lastseen, datetime.datetime.utcnow())
+        returned_dict["last_seen"] = timeago_format(self.dt_lastseen, datetime.datetime.utcnow())
         returned_dict["blocks"] = [block.to_dict() for block in self.get_blocks()]
         returned_dict.pop("password")
         returned_dict.pop("previous_reset_token")
@@ -237,7 +237,7 @@ class User(Model):
             "email": self.email,
             "username": self.username,
             "is_online": self.is_online,
-            "date_lastseen": self.date_lastseen,
+            "dt_lastseen": self.dt_lastseen,
         }
 
     def get_images(self):
@@ -318,7 +318,7 @@ class User(Model):
         return match_list
 
     def send_message(self, to_id, content):
-        Message.create(from_id=self.id, to_id=to_id, content=content, timestamp=datetime.datetime.utcnow())
+        Message.create(from_id=self.id, to_id=to_id, content=content, dt_sent=datetime.datetime.utcnow())
 
     def get_messages(self) -> List[Message]:
         with self.db.cursor() as c:
@@ -328,8 +328,8 @@ class User(Model):
                 messages.from_id as from_id, 
                 messages.to_id as to_id, 
                 messages.id as id, 
-                messages.timestamp as timestamp, 
-                messages.seen_timestamp as seen_timestamp, 
+                messages.dt_sent as dt_sent,
+                messages.dt_seen as dt_seen,
                 messages.content as content, 
                 messages.is_liked as is_liked, 
                 messages.is_seen as is_seen
@@ -386,8 +386,8 @@ class User(Model):
                 messages.from_id as from_id, 
                 messages.to_id as to_id, 
                 messages.id as id, 
-                messages.timestamp as timestamp, 
-                messages.seen_timestamp as seen_timestamp, 
+                messages.dt_sent as dt_sent,
+                messages.dt_seen as dt_seen,
                 messages.content as content, 
                 messages.is_liked as is_liked, 
                 messages.is_seen as is_seen
@@ -399,8 +399,8 @@ class User(Model):
                 SELECT messages.from_id as from_id, 
                 messages.to_id as to_id, 
                 messages.id as id, 
-                messages.timestamp as timestamp, 
-                messages.seen_timestamp as seen_timestamp, 
+                messages.dt_sent as dt_sent,
+                messages.dt_seen as dt_seen,
                 messages.content as content, 
                 messages.is_liked as is_liked, 
                 messages.is_seen as is_seen

--- a/backend/PyMatcha/routes/api/auth/login.py
+++ b/backend/PyMatcha/routes/api/auth/login.py
@@ -71,7 +71,7 @@ def auth_login():
 
     current_app.logger.debug("/auth/login -> Returning access token for user {}".format(username))
     u.is_online = True
-    u.date_lastseen = datetime.datetime.utcnow()
+    u.dt_lastseen = datetime.datetime.utcnow()
     u.save()
     ret = {"access_token": access_token, "refresh_token": refresh_token, "is_profile_completed": u.is_profile_completed}
     return SuccessOutput("return", ret)

--- a/backend/PyMatcha/routes/api/messages.py
+++ b/backend/PyMatcha/routes/api/messages.py
@@ -48,8 +48,8 @@ def get_opened_conversations():
     returned_list = [
         {
             "last_message_id": c.id,
-            "last_message_timestamp": c.dt_sent,
-            "last_message_timestamp_ago": timeago_format(c.dt_sent, datetime.datetime.utcnow()),
+            "last_message_dt_sent": c.dt_sent,
+            "last_message_dt_sent_ago": timeago_format(c.dt_sent, datetime.datetime.utcnow()),
             "last_message_content": c.content,
             "is_unseen": True if not c.is_seen and c.to_id == current_user.id else False,
             "with_user": get_user(c.to_id if c.to_id != current_user.id else c.from_id).to_dict(),

--- a/backend/PyMatcha/routes/api/messages.py
+++ b/backend/PyMatcha/routes/api/messages.py
@@ -48,8 +48,8 @@ def get_opened_conversations():
     returned_list = [
         {
             "last_message_id": c.id,
-            "last_message_timestamp": c.timestamp,
-            "last_message_timestamp_ago": timeago_format(c.timestamp, datetime.datetime.utcnow()),
+            "last_message_timestamp": c.dt_sent,
+            "last_message_timestamp_ago": timeago_format(c.dt_sent, datetime.datetime.utcnow()),
             "last_message_content": c.content,
             "is_unseen": True if not c.is_seen and c.to_id == current_user.id else False,
             "with_user": get_user(c.to_id if c.to_id != current_user.id else c.from_id).to_dict(),
@@ -90,7 +90,7 @@ def send_message():
 
     if to_user.is_bot:
         new_message.is_seen = True
-        new_message.seen_timestamp = datetime.datetime.utcnow()
+        new_message.dt_seen = datetime.datetime.utcnow()
         new_message.save()
         bot_respond_to_message.delay(bot_id=to_user.id, from_id=current_user.id, message_content=content)
 
@@ -110,7 +110,7 @@ def get_conversation_messsages(with_uid):
 
     message_list = current_user.get_messages_with_user(with_user.id)
     message_list = [m.to_dict() for m in message_list]
-    message_list = sorted(message_list, key=lambda item: item["timestamp"])
+    message_list = sorted(message_list, key=lambda item: item["dt_sent"])
     return SuccessOutput("messages", message_list)
 
 
@@ -124,7 +124,7 @@ def see_conversation_messages(with_uid):
     unseen_messages = Message.get_multis(from_id=with_user.id, to_id=current_user.id, is_seen=False)
     for message in unseen_messages:
         message.is_seen = True
-        message.seen_timestamp = datetime.datetime.utcnow()
+        message.dt_seen = datetime.datetime.utcnow()
         message.save()
     return Success("Messages marked as seen.")
 

--- a/backend/PyMatcha/utils/jwt_callbacks.py
+++ b/backend/PyMatcha/utils/jwt_callbacks.py
@@ -37,7 +37,7 @@ def jwt_user_callback(identity):
     with configure_scope() as scope:
         scope.user = {"email": user.email, "id": user.id, "username": user.username}
     user.is_online = True
-    user.date_lastseen = datetime.datetime.utcnow()
+    user.dt_lastseen = datetime.datetime.utcnow()
     user.save()
     return user
 

--- a/backend/PyMatcha/utils/populate_database.py
+++ b/backend/PyMatcha/utils/populate_database.py
@@ -70,9 +70,9 @@ def populate_users(amount=150, drop_user_table=False):
             old = geohash[0:2]
             geohash = geohash.replace(old, FRANCE_GEOHASH_START[0], 1)
 
-        date_joined = gen_datetime(min_year=2017, max_year=datetime.datetime.now().year)
+        dt_joined = gen_datetime(min_year=2017, max_year=datetime.datetime.now().year)
 
-        date_lastseen = gen_datetime(min_year=2017, max_year=datetime.datetime.now().year)
+        dt_lastseen = gen_datetime(min_year=2017, max_year=datetime.datetime.now().year)
         username = user.get_username()
 
         birthdate = gen_datetime(min_year=1985, max_year=datetime.datetime.now().year - 18).date()
@@ -90,8 +90,8 @@ def populate_users(amount=150, drop_user_table=False):
                 geohash=geohash,
                 heat_score=random.randint(0, 150),
                 is_online=random.choice([True, False]),
-                date_joined=date_joined,
-                date_lastseen=date_lastseen,
+                dt_joined=dt_joined,
+                dt_lastseen=dt_lastseen,
                 is_profile_completed=True,
                 is_confirmed=True,
                 confirmed_on=datetime.datetime.utcnow(),

--- a/backend/PyMatcha/utils/tables.py
+++ b/backend/PyMatcha/utils/tables.py
@@ -42,8 +42,8 @@ def _create_user_table(db):
         birthdate            DATE DEFAULT NULL,
         geohash              VARCHAR(256) DEFAULT NULL,
         heat_score           INT DEFAULT NULL,
-        date_joined          DATETIME DEFAULT NOW(),
-        date_lastseen        DATETIME DEFAULT NOW(),
+        dt_joined            DATETIME DEFAULT NOW(),
+        dt_lastseen          DATETIME DEFAULT NOW(),
         previous_reset_token VARCHAR(256),
         is_online            BOOLEAN DEFAULT (FALSE),
         is_profile_completed BOOLEAN DEFAULT (FALSE),
@@ -168,8 +168,8 @@ def _create_messages_table(db):
         id             INT auto_increment PRIMARY KEY,
         from_id        INT NOT NULL,
         to_id          INT NOT NULL,
-        timestamp      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        seen_timestamp TIMESTAMP,
+        dt_sent        DATETIME DEFAULT NOW(),
+        dt_seen        DATETIME DEFAULT NOW(),
         content        LONGTEXT NOT NULL,
         is_liked       BOOLEAN DEFAULT FALSE,
         is_seen        BOOLEAN DEFAULT FALSE
@@ -190,7 +190,7 @@ def _create_images_table(db):
         (
         id             INT auto_increment PRIMARY KEY,
         user_id        INT NOT NULL,
-        timestamp      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        dt_added       DATETIME DEFAULT NOW(),
         link           VARCHAR(256) NOT NULL,
         is_primary     BOOLEAN DEFAULT FALSE
         ) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci ;

--- a/backend/PyMatcha/utils/tasks.py
+++ b/backend/PyMatcha/utils/tasks.py
@@ -61,7 +61,7 @@ def update_heat_scores():
 
         now = datetime.datetime.utcnow()
         monday1 = now - datetime.timedelta(days=now.weekday())
-        monday2 = user.date_lastseen - datetime.timedelta(days=user.date_lastseen.weekday())
+        monday2 = user.dt_lastseen - datetime.timedelta(days=user.dt_lastseen.weekday())
         weeks_passed_since_last_activity = int((monday1 - monday2).days / 7)
 
         score -= weeks_passed_since_last_activity * INACTIVITY_DIVIDER
@@ -78,7 +78,7 @@ def take_users_offline():
     went_offline_count = 0
     stayed_online_count = 0
     for user in User.get_multis(is_online=True):
-        if user.date_lastseen + datetime.timedelta(minutes=2) < datetime.datetime.utcnow():
+        if user.dt_lastseen + datetime.timedelta(minutes=2) < datetime.datetime.utcnow():
             user.is_online = False
             user.save()
             went_offline_count += 1
@@ -142,7 +142,7 @@ def take_random_users_online():
             # User isn't a bot, so skip him
             continue
         user.is_online = True
-        user.date_lastseen = datetime.datetime.utcnow()
+        user.dt_lastseen = datetime.datetime.utcnow()
         user.save()
     return "Successfully set 250 users online"
 

--- a/backend/schemas/swagger.yaml
+++ b/backend/schemas/swagger.yaml
@@ -1728,10 +1728,10 @@ components:
         confirmed_on:
           type: date
           example: Wed, 16 Sep 2020 15:20:02 GMT
-        date_joined:
+        dt_joined:
           type: date
           example: Wed, 16 Sep 2020 15:18:02 GMT
-        date_lastseen:
+        dt_lastseen:
           type: date
           example: Wed, 19 Sep 2020 19:24:02 GMT
         is_confirmed:
@@ -1945,11 +1945,11 @@ components:
           type: integer
           example: 1
           description: The unique id of the message
-        timestamp:
+        dt_added:
           type: date
           description: When was the message sent
           example: Wed, 16 Sep 2020 15:38:15 GMT
-        seen_timestamp:
+        dt_seen:
           type: date
           description: When was the message seen
           example: Wed, 16 Sep 2020 15:39:15 GMT
@@ -1980,11 +1980,11 @@ components:
           type: integer
           example: 1
           description: The unique id of the message
-        timestamp:
+        dt_added:
           type: date
           description: When was the message sent
           example: Wed, 16 Sep 2020 15:38:15 GMT
-        seen_timestamp:
+        dt_seen:
           type: date
           description: When was the message seen
           example: Wed, 16 Sep 2020 15:39:15 GMT
@@ -2060,10 +2060,10 @@ components:
         confirmed_on:
           type: date
           example: Wed, 16 Sep 2020 15:20:02 GMT
-        date_joined:
+        dt_joined:
           type: date
           example: Wed, 16 Sep 2020 15:18:02 GMT
-        date_lastseen:
+        dt_lastseen:
           type: date
           example: Wed, 19 Sep 2020 19:24:02 GMT
         is_confirmed:
@@ -2121,7 +2121,7 @@ components:
           type: integer
           description: The user id
           example: 1
-        date_lastseen:
+        dt_lastseen:
           type: timestamp
           description: Timestamp of last time the user was online
           example: 1600332058.537065,
@@ -2140,7 +2140,7 @@ components:
           type: string
           description: The image link
           example: https://i.imgur.com/OCqF907.png
-        timestamp:
+        dt_added:
           type: date
           description: When was the image added
           example: Wed, 19 Sep 2020 19:24:02 GMT
@@ -2196,10 +2196,10 @@ components:
         confirmed_on:
           type: date
           example: Wed, 16 Sep 2020 15:20:02 GMT
-        date_joined:
+        dt_joined:
           type: date
           example: Wed, 16 Sep 2020 15:18:02 GMT
-        date_lastseen:
+        dt_lastseen:
           type: date
           example: Wed, 19 Sep 2020 19:24:02 GMT
         is_confirmed:

--- a/frontend/src/components/app/matches/Chat.vue
+++ b/frontend/src/components/app/matches/Chat.vue
@@ -63,9 +63,9 @@ export default {
     determineFirstMessagesOfTimespans(messages) {
       const len = messages.length;
       for (let i = 0; i < len; i += 1) {
-        if (this.displayDate(messages[i].timestamp)) {
+        if (this.displayDate(messages[i].dt_sent)) {
           messages[i].first_in_timespan = true;
-          messages[i].timestamp_first = this.getDayMonthday(messages[i].timestamp);
+          messages[i].timestamp_first = this.getDayMonthday(messages[i].dt_sent);
         } else {
           messages[i].first_in_timespan = false;
         }
@@ -112,8 +112,9 @@ export default {
       const messagesRequest = await this.$http.get(`/conversations/${this.chatWithUserId}`);
       const newMessages = messagesRequest.data.messages;
       const oldMessageCount = this.messages.length;
-      this.determineFirstMessagesOfTimespans(newMessages);
       this.messages = newMessages;
+      this.latestMessagesDate = null;
+      this.determineFirstMessagesOfTimespans(this.messages);
       if (newMessages.length > oldMessageCount) {
         this.$emit('new-message');
         this.scrollChatToBottom();

--- a/frontend/src/components/app/matches/Message.vue
+++ b/frontend/src/components/app/matches/Message.vue
@@ -21,7 +21,7 @@
     <div class="ml-4 w-full">
       <div class="flex justify-between">
         <h1 class="font-bold">{{this.match.first_name}}</h1>
-        <h1 class="text-sm opacity-50">{{this.message.last_message_timestamp_ago}}</h1>
+        <h1 class="text-sm opacity-50">{{this.message.last_message_dt_sent_ago}}</h1>
       </div>
       <h1 v-bind:class="{'opacity-50': this.message.is_unseen}">{{getMessage}}</h1>
     </div>

--- a/frontend/src/components/app/matches/MessageBubble.vue
+++ b/frontend/src/components/app/matches/MessageBubble.vue
@@ -18,11 +18,11 @@
             'bg-purple-matcha': message.to_id === loggedInUserId,
             'bg-green-500': message.to_id !== loggedInUserId,
             'text-white-matcha': true}"
-    >{{message.content}}<span class="block text-sm font-light">{{getDateHoursMinutes(message.timestamp)}}</span></h1>
+    >{{message.content}}<span class="block text-sm font-light">{{getDateHoursMinutes(message.dt_sent)}}</span></h1>
     <img v-if="message.to_id === loggedInUserId && message.is_liked"
          src="../../../assets/heartGreen.png" class="w-6 ml-2 inline-block absolute heart"
          v-on:dblclick="likeMessage(message.id, message.is_liked)">
-    <h1 v-if="last" class="text-gray-600">{{getSeenMessage(message.is_seen, message.timestamp_ago)}}</h1>
+    <h1 v-if="last" class="text-gray-600">{{getSeenMessage(message.is_seen, message.dt_seen_ago)}}</h1>
   </div>
 </template>
 

--- a/frontend/src/views/auth/SignOut.vue
+++ b/frontend/src/views/auth/SignOut.vue
@@ -4,13 +4,17 @@
 
 <script>
 
+/* eslint-disable no-empty */
+
 export default {
   name: 'SignOut',
   async mounted() {
-    await this.$http.post('/auth/logout', {
-      access_token: localStorage.getItem(process.env.VUE_APP_ACCESS_TOKEN),
-      refresh_token: localStorage.getItem(process.env.VUE_APP_REFRESH_TOKEN),
-    });
+    try {
+      await this.$http.post('/auth/logout', {
+        access_token: localStorage.getItem(process.env.VUE_APP_ACCESS_TOKEN),
+        refresh_token: localStorage.getItem(process.env.VUE_APP_REFRESH_TOKEN),
+      });
+    } catch (e) {}
     localStorage.removeItem(process.env.VUE_APP_ACCESS_TOKEN);
     localStorage.removeItem(process.env.VUE_APP_REFRESH_TOKEN);
     localStorage.removeItem(process.env.VUE_APP_VUEX_PERSISTED_STATE);

--- a/mysql_dump/users-dump.sql
+++ b/mysql_dump/users-dump.sql
@@ -50,7 +50,7 @@ DROP TABLE IF EXISTS `images`;
 CREATE TABLE `images` (
   `id` int NOT NULL AUTO_INCREMENT,
   `user_id` int NOT NULL,
-  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `dt_added` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `link` varchar(256) NOT NULL,
   `is_primary` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`)
@@ -129,8 +129,8 @@ CREATE TABLE `messages` (
   `id` int NOT NULL AUTO_INCREMENT,
   `from_id` int NOT NULL,
   `to_id` int NOT NULL,
-  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `seen_timestamp` timestamp NULL DEFAULT NULL,
+  `dt_sent` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `dt_seen` timestamp NULL DEFAULT NULL,
   `content` longtext NOT NULL,
   `is_liked` tinyint(1) DEFAULT '0',
   `is_seen` tinyint(1) DEFAULT '0',
@@ -248,8 +248,8 @@ CREATE TABLE `users` (
   `birthdate` date DEFAULT NULL,
   `geohash` varchar(256) DEFAULT NULL,
   `heat_score` int DEFAULT NULL,
-  `date_joined` datetime DEFAULT CURRENT_TIMESTAMP,
-  `date_lastseen` datetime DEFAULT CURRENT_TIMESTAMP,
+  `dt_joined` datetime DEFAULT CURRENT_TIMESTAMP,
+  `dt_lastseen` datetime DEFAULT CURRENT_TIMESTAMP,
   `previous_reset_token` varchar(256) DEFAULT NULL,
   `is_online` tinyint(1) DEFAULT (false),
   `is_profile_completed` tinyint(1) DEFAULT (false),
@@ -308,4 +308,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2020-11-03 13:50:40
+-- Dump completed on 2020-11-03 19:32:02


### PR DESCRIPTION
Closes #368

Reasoning is, none is a timestamp, they're all datetimes

On this PR @supalarry, I renamed the following fields:

User:

- date_joined -> `dt_joined`
- date_lastseen -> `dt_lastseen`

Message:
- timestamp -> `dt_sent`
- seen_timestamp -> `dt_seen`

Image:
- timestamp -> dt_added

Can you please change those where you use them in the frontend and push it on this PR ? Once done we'll test and merge